### PR TITLE
$serverurl update - UpdateMinecraftServers.ps1

### DIFF
--- a/UpdateMinecraftServers.ps1
+++ b/UpdateMinecraftServers.ps1
@@ -91,10 +91,10 @@ try {
     $requestResult = Invoke-WebRequest @InvokeWebRequestSplatt
     if ($requestResult -and $requestResult.Links) {
         # Parse download link and file name
-        $serverurl = $requestResult.Links | select href | where {$_.href -like "https://minecraft.azureedge.net/bin-win/bedrock-server*"}
+        $serverurl = $requestResult.Links | select href | where {$_.href -like "https://www.minecraft.net/bedrockdedicatedserver/bin-win/bedrock-server*"}
         if ($serverurl) {
             $url = $serverurl.href
-            $filename = $url.Replace("https://minecraft.azureedge.net/bin-win/", "")
+            $filename = $url.Replace("https://www.minecraft.net/bedrockdedicatedserver/bin-win/", "")
             $output = "$updateDir\$filename"
             Log-Message "NEWEST UPDATE AVAILABLE: $filename"
         } else {


### PR DESCRIPTION
Changed $serverurl to www.minecraft.net/bedrockdedicatedserver/

$serverurl = $requestResult.Links | select href | where {$_.href -like "https://www.minecraft.net/bedrockdedicatedserver/bin-win/bedrock-server*"}

$filename = $url.Replace("https://www.minecraft.net/bedrockdedicatedserver/bin-win/", "")